### PR TITLE
fix: Move @nestjs/common to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,10 +17,12 @@
     "prerelease": "npm run build",
     "release": "release-it"
   },
+  "dependencies": {
+    "@nestjs/common": "7.3.2"
+  },
   "devDependencies": {
     "@commitlint/cli": "9.1.1",
     "@commitlint/config-angular": "9.1.1",
-    "@nestjs/common": "7.3.2",
     "@types/jest": "26.0.7",
     "@types/node": "7.10.8",
     "@typescript-eslint/eslint-plugin": "3.7.1",


### PR DESCRIPTION
It is imported in the code, so it should be a normal dependency.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

Because `@nestjs/common` is currently in the dev dependencies this results in `@nestjs/common` not being able to be found in certain project configurations. In my case `@nestjs/common` ends up in `node_modules` inside a package of a monorepo and `@nestjs/mapped-types` in the root `node_modules`.

Issue Number: N/A


## What is the new behavior?

Because `@nestjs/common` is a direct dependency it will always be able to be found.

## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information