### PR TITLE
feat: Allow IntersectionType to accept any count of arguments, and join them together

### DIFF
--- a/lib/intersection-type.helper.ts
+++ b/lib/intersection-type.helper.ts
@@ -6,24 +6,31 @@ import {
   inheritValidationMetadata,
 } from './type-helpers.utils';
 
-export function IntersectionType<A, B>(
-  classARef: Type<A>,
-  classBRef: Type<B>,
-): MappedType<A & B> {
+export function IntersectionType<A, T extends { new (...arg: any): any }[]>(
+  classA: Type<A>,
+  ...classRefs: T
+): MappedType<A> {
+  const allClassRefs = [classA, ...classRefs];
+
   abstract class IntersectionClassType {
     constructor() {
-      inheritPropertyInitializers(this, classARef);
-      inheritPropertyInitializers(this, classBRef);
+      allClassRefs.forEach((classRef) => {
+        inheritPropertyInitializers(this, classRef);
+      });
     }
   }
 
-  inheritValidationMetadata(classARef, IntersectionClassType);
-  inheritValidationMetadata(classBRef, IntersectionClassType);
-  inheritTransformationMetadata(classARef, IntersectionClassType);
-  inheritTransformationMetadata(classBRef, IntersectionClassType);
-
-  Object.defineProperty(IntersectionClassType, 'name', {
-    value: `Intersection${classARef.name}${classBRef.name}`,
+  allClassRefs.forEach((classRef) => {
+    inheritValidationMetadata(classRef, IntersectionClassType);
+    inheritTransformationMetadata(classRef, IntersectionClassType);
   });
-  return IntersectionClassType as MappedType<A & B>;
+
+  const intersectedNames = allClassRefs.reduce(
+    (prev, ref) => prev + ref.name,
+    '',
+  );
+  Object.defineProperty(IntersectionClassType, 'name', {
+    value: `Intersection${intersectedNames}`,
+  });
+  return IntersectionClassType as MappedType<A>;
 }

--- a/lib/intersection-type.helper.ts
+++ b/lib/intersection-type.helper.ts
@@ -6,6 +6,24 @@ import {
   inheritValidationMetadata,
 } from './type-helpers.utils';
 
+export function IntersectionType<A, B>(
+  target: Type<A>,
+  source: Type<B>,
+): MappedType<A & B>;
+
+export function IntersectionType<A, B, C>(
+  target: Type<A>,
+  sourceB: Type<B>,
+  sourceC: Type<C>,
+): MappedType<A & B & C>;
+
+export function IntersectionType<A, B, C, D>(
+  target: Type<A>,
+  sourceB: Type<B>,
+  sourceC: Type<C>,
+  sourceD: Type<D>,
+): MappedType<A & B & C & D>;
+
 export function IntersectionType<A, T extends { new (...arg: any): any }[]>(
   classA: Type<A>,
   ...classRefs: T

--- a/tests/intersection-type-multiple.helper.spec.ts
+++ b/tests/intersection-type-multiple.helper.spec.ts
@@ -31,7 +31,6 @@ describe('IntersectionType', () => {
     patronymic!: string;
   }
 
-  interface UpdateUserDto extends ClassA, ClassB, ClassC {}
   class UpdateUserDto extends IntersectionType(ClassA, ClassB, ClassC) {}
 
   describe('Validation metadata', () => {

--- a/tests/intersection-type.helper.spec.ts
+++ b/tests/intersection-type.helper.spec.ts
@@ -22,7 +22,6 @@ describe('IntersectionType', () => {
     lastName!: string;
   }
 
-  interface UpdateUserDto extends ClassA, ClassB {}
   class UpdateUserDto extends IntersectionType(ClassA, ClassB) {}
 
   describe('Validation metadata', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
Allow IntersectionType to accept any count of arguments, and join them together.

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #339

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
Waiting for discussion...

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
Cannot found any possible solution to get union type of rest parameters  `(...args: T)` into one type, for example `Object.assign` interface in typescript.
We could do workaround such this: 

```typescript
interface ObjectConstructor {
    assign<T, U>(target: T, source: U): T & U;
    assign<T, U, V>(target: T, source1: U, source2: V): T & U & V;
    assign<T, U, V, W>(target: T, source1: U, source2: V, source3: W): T & U & V & W;
    assign(target: object, ...sources: any[]): any;
    ...
}
```
and add documentation, if u have more than 4 parameters to use interface like this:
```typescript
interface UpdateUserDto extends ClassA, ClassB, ClassC, ClassD {}
class UpdateUserDto extends IntersectionType(ClassA, ClassB, ClassC, ClassD) {}
```

