### PR TITLE
chore: mark optional peer dependencies properly

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,14 @@
     "class-validator": "^0.11.1 || ^0.12.0 || ^0.13.0",
     "reflect-metadata": "^0.1.12"
   },
+  "peerDependenciesMeta": {
+    "class-validator": {
+      "optional": true
+    },
+    "class-transformer": {
+      "optional": true
+    }
+  }
   "lint-staged": {
     "*.ts": [
       "prettier --write"


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

When installing `@nestjs/swagger` without `class-validator` and `class-transformer` packages, we got these warnings:

```
warning "@nestjs/swagger > @nestjs/mapped-types@1.0.0" has unmet peer dependency "class-transformer@^0.2.0 || ^0.3.0 || ^0.4.0".
warning "@nestjs/swagger > @nestjs/mapped-types@1.0.0" has unmet peer dependency "class-validator@^0.11.1 || ^0.12.0 || ^0.13.0".
```

## What is the new behavior?

Since `class-validator` and `class-transformer` aren't required for consumers of this package, they must be marked as optional.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information