### PR TITLE
fix: IntersectionType intersects more than 4 classes

### DIFF
--- a/lib/intersection-type.helper.ts
+++ b/lib/intersection-type.helper.ts
@@ -1,4 +1,5 @@
 import { Type } from '@nestjs/common';
+
 import { MappedType } from './mapped-type.interface';
 import {
   inheritPropertyInitializers,
@@ -6,49 +7,45 @@ import {
   inheritValidationMetadata,
 } from './type-helpers.utils';
 
-export function IntersectionType<A, B>(
-  target: Type<A>,
-  source: Type<B>,
-): MappedType<A & B>;
+// https://stackoverflow.com/questions/50374908/transform-union-type-to-intersection-type
+type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (
+  k: infer I,
+) => void
+  ? I
+  : never;
 
-export function IntersectionType<A, B, C>(
-  target: Type<A>,
-  sourceB: Type<B>,
-  sourceC: Type<C>,
-): MappedType<A & B & C>;
+// It converts ClassRefs array `Type<Class>[]` to `Class[]` by `infer`
+// e.g. `ClassRefsToConstructors<[Type<Foo>, Type<Bar>]>` becomes `[Foo, Bar]`
+type ClassRefsToConstructors<T extends Type[]> = {
+  [U in keyof T]: T[U] extends Type<infer V> ? V : never;
+};
 
-export function IntersectionType<A, B, C, D>(
-  target: Type<A>,
-  sourceB: Type<B>,
-  sourceC: Type<C>,
-  sourceD: Type<D>,
-): MappedType<A & B & C & D>;
+// Firstly, it uses indexed access type `Class[][number]` to convert `Class[]` to union type of it
+// e.g. `[Foo, Bar][number]` becomes `Foo | Bar`
+// then, it use the `UnionToIntersection` type to transform union type to intersection type
+// e.g. `Foo | Bar` becomes `Foo & Bar`
+// finally, put them into `MappedType` as the original implementation
+type Intersection<T extends Type[]> = MappedType<
+  UnionToIntersection<ClassRefsToConstructors<T>[number]>
+>;
 
-export function IntersectionType<A, T extends { new (...arg: any): any }[]>(
-  classA: Type<A>,
-  ...classRefs: T
-): MappedType<A> {
-  const allClassRefs = [classA, ...classRefs];
-
+export function IntersectionType<T extends Type[]>(...classRefs: T) {
   abstract class IntersectionClassType {
     constructor() {
-      allClassRefs.forEach((classRef) => {
+      classRefs.forEach((classRef) => {
         inheritPropertyInitializers(this, classRef);
       });
     }
   }
 
-  allClassRefs.forEach((classRef) => {
+  classRefs.forEach((classRef) => {
     inheritValidationMetadata(classRef, IntersectionClassType);
     inheritTransformationMetadata(classRef, IntersectionClassType);
   });
 
-  const intersectedNames = allClassRefs.reduce(
-    (prev, ref) => prev + ref.name,
-    '',
-  );
+  const intersectedNames = classRefs.reduce((prev, ref) => prev + ref.name, '');
   Object.defineProperty(IntersectionClassType, 'name', {
     value: `Intersection${intersectedNames}`,
   });
-  return IntersectionClassType as MappedType<A>;
+  return IntersectionClassType as Intersection<T>;
 }

--- a/lib/intersection-type.helper.ts
+++ b/lib/intersection-type.helper.ts
@@ -22,9 +22,9 @@ type ClassRefsToConstructors<T extends Type[]> = {
 
 // Firstly, it uses indexed access type `Class[][number]` to convert `Class[]` to union type of it
 // e.g. `[Foo, Bar][number]` becomes `Foo | Bar`
-// then, it use the `UnionToIntersection` type to transform union type to intersection type
+// then, uses the `UnionToIntersection` type to transform union type to intersection type
 // e.g. `Foo | Bar` becomes `Foo & Bar`
-// finally, put them into `MappedType` as the original implementation
+// finally, returns `MappedType` passing the generated intersection type as a type argument
 type Intersection<T extends Type[]> = MappedType<
   UnionToIntersection<ClassRefsToConstructors<T>[number]>
 >;

--- a/lib/intersection-type.helper.ts
+++ b/lib/intersection-type.helper.ts
@@ -14,7 +14,7 @@ type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (
   ? I
   : never;
 
-// It converts ClassRefs array `Type<Class>[]` to `Class[]` by `infer`
+// Converts ClassRefs array `Type<Class>[]` to `Class[]` using `infer`
 // e.g. `ClassRefsToConstructors<[Type<Foo>, Type<Bar>]>` becomes `[Foo, Bar]`
 type ClassRefsToConstructors<T extends Type[]> = {
   [U in keyof T]: T[U] extends Type<infer V> ? V : never;

--- a/tests/intersection-type-multiple.helper.spec.ts
+++ b/tests/intersection-type-multiple.helper.spec.ts
@@ -31,7 +31,23 @@ describe('IntersectionType', () => {
     patronymic!: string;
   }
 
-  class UpdateUserDto extends IntersectionType(ClassA, ClassB, ClassC) {}
+  class ClassD {
+    @IsString()
+    alpha = 'defaultStringAlpha';
+  }
+
+  class ClassE {
+    @IsString()
+    beta = 'defaultStringBeta';
+  }
+
+  class UpdateUserDto extends IntersectionType(
+    ClassA,
+    ClassB,
+    ClassC,
+    ClassD,
+    ClassE,
+  ) {}
 
   describe('Validation metadata', () => {
     it('should inherit metadata for all properties from class A and class B', () => {
@@ -45,6 +61,8 @@ describe('IntersectionType', () => {
         'lastName',
         'hash',
         'patronymic',
+        'alpha',
+        'beta',
       ]);
     });
     describe('when object does not fulfil validation rules', () => {
@@ -74,6 +92,8 @@ describe('IntersectionType', () => {
         updateDto.lastName = 'lastNameTest';
         updateDto.login = 'mylogintesttest';
         updateDto.patronymic = 'patronymicTest';
+        updateDto.alpha = 'alphaTest';
+        updateDto.beta = 'betaTest';
 
         const validationErrors = await validate(updateDto);
         expect(validationErrors.length).toEqual(0);
@@ -105,6 +125,8 @@ describe('IntersectionType', () => {
       expect(updateUserDto.login).toEqual('defaultLoginWithMin10Chars');
       expect(updateUserDto.firstName).toEqual('defaultFirst');
       expect(updateUserDto.hash).toEqual('defaultHashWithMin5Chars');
+      expect(updateUserDto.alpha).toEqual('defaultStringAlpha');
+      expect(updateUserDto.beta).toEqual('defaultStringBeta');
     });
   });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

* [x]  The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
* [x]  Tests for the changes have been added (for bug fixes / features)
* [ ]  Docs have been added / updated (for bug fixes / features)

## PR Type
Allow IntersectionType to accept any count of arguments, and join them together.

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
It doesn't accept more than 4 classes, blocked by the overloads.
And the return type of the original function is wrong, it only takes the first arg's type.

![ScreenCap 2022-09-29 PM 5 19 16](https://user-images.githubusercontent.com/57888887/192993167-fe816f23-ca24-4f34-a363-4f5656b41b3c.png)

Also has a closed issue for this: #860

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information

Fixing the problems in the discussion section of #341 

Not sure if the helper types should be placed into a separate file since they only serve this function only
