### PR TITLE
chore: allow class-validator 0.14.x as peerDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "peerDependencies": {
     "@nestjs/common": "^7.0.8 || ^8.0.0 || ^9.0.0",
     "class-transformer": "^0.2.0 || ^0.3.0 || ^0.4.0 || ^0.5.0",
-    "class-validator": "^0.11.1 || ^0.12.0 || ^0.13.0",
+    "class-validator": "^0.11.1 || ^0.12.0 || ^0.13.0 || ^0.14.0",
     "reflect-metadata": "^0.1.12"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
I cannot use package with higher version of class-validator

Issue Number: N/A


## What is the new behavior?
I will be able to install newer dependency :D 

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
