### PR TITLE
fix(deps): update class validator peer dependency to allow latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "peerDependencies": {
     "@nestjs/common": "^7.0.8 || ^8.0.0 || ^9.0.0",
     "class-transformer": "^0.2.0 || ^0.3.0 || ^0.4.0 || ^0.5.0",
-    "class-validator": "^0.11.1 || ^0.12.0 || ^0.13.0",
+    "class-validator": "^0.11.1 || ^0.12.0 || ^0.13.0 || ^0.14.0",
     "reflect-metadata": "^0.1.12"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
there is a vulnerability affecting all the older versions https://nvd.nist.gov/vuln/detail/CVE-2019-18413
and version 14 now is not listed as peerDependency here, so updating to 14 throw npm error

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
