### PR TITLE
Allow class-validator 0.14.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "peerDependencies": {
     "@nestjs/common": "^7.0.8 || ^8.0.0 || ^9.0.0",
     "class-transformer": "^0.2.0 || ^0.3.0 || ^0.4.0 || ^0.5.0",
-    "class-validator": "^0.11.1 || ^0.12.0 || ^0.13.0",
+    "class-validator": "^0.11.1 || ^0.12.0 || ^0.13.0 || ^0.14.0",
     "reflect-metadata": "^0.1.12"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
Currently `@nestjs/mapped-types` and therefor `@nestjs/swagger` produced peerDependency errors because `0.14.0` was missing in peerDeps.

Maybe the versions of `class-validator` and `class-transformer` should even be changed to `"*"` - this is at least what `@nestjs/swagger` does.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Other... Please describe: Updated peerDependencies

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No
