### PR TITLE
chore(lint-config): prettier/@typescript-eslint must be removed

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,7 +9,6 @@ module.exports = {
     'plugin:@typescript-eslint/eslint-recommended',
     'plugin:@typescript-eslint/recommended',
     'prettier',
-    'prettier/@typescript-eslint',
   ],
   root: true,
   env: {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [X] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

When running `npm run lint` locally, the command does not complete due to an error:

```
$ npm run lint

> @nestjs/mapped-types@1.2.0 lint
> eslint 'lib/**/*.ts' --fix


Oops! Something went wrong! :(

ESLint: 8.32.0

Error: Cannot read config file: /Users/rossm/projects/mapped-types/node_modules/eslint-config-prettier/@typescript-eslint.js
Error: "prettier/@typescript-eslint" has been merged into "prettier" in eslint-config-prettier 8.0.0. See: https://github.com/prettier/eslint-config-prettier/blob/main/CHANGELOG.md#version-800-2021-02-21
Referenced from: /Users/rossm/projects/mapped-types/.eslintrc.js
    at Object.<anonymous> (/Users/rossm/projects/mapped-types/node_modules/eslint-config-prettier/@typescript-eslint.js:1:7)
    at Module._compile (node:internal/modules/cjs/loader:1218:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1272:10)
    at Module.load (node:internal/modules/cjs/loader:1081:32)
    at Module._load (node:internal/modules/cjs/loader:922:12)
    at Module.require (node:internal/modules/cjs/loader:1105:19)
    at module.exports [as default] (/Users/rossm/projects/mapped-types/node_modules/import-fresh/index.js:31:59)
    at loadJSConfigFile (/Users/rossm/projects/mapped-types/node_modules/@eslint/eslintrc/dist/eslintrc.cjs:2562:47)
    at loadConfigFile (/Users/rossm/projects/mapped-types/node_modules/@eslint/eslintrc/dist/eslintrc.cjs:2646:20)
    at ConfigArrayFactory._loadConfigData (/Users/rossm/projects/mapped-types/node_modules/@eslint/eslintrc/dist/eslintrc.cjs:2963:42)
```

Issue Number: [962](https://github.com/nestjs/mapped-types/issues/962)


## What is the new behavior?


The fix for this error is exactly as the error message prescribes: remove `prettier/@typescript-eslint` from the eslint configuration.

The linting action runs successfully.

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

