### PR TITLE
Remove functions fields from mapped types

### DIFF
--- a/lib/intersection-type.helper.ts
+++ b/lib/intersection-type.helper.ts
@@ -6,6 +6,7 @@ import {
   inheritTransformationMetadata,
   inheritValidationMetadata,
 } from './type-helpers.utils';
+import { RemoveFieldsWithType } from './types/remove-fields-with-type.type';
 
 // https://stackoverflow.com/questions/50374908/transform-union-type-to-intersection-type
 type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (
@@ -26,7 +27,10 @@ type ClassRefsToConstructors<T extends Type[]> = {
 // e.g. `Foo | Bar` becomes `Foo & Bar`
 // finally, returns `MappedType` passing the generated intersection type as a type argument
 type Intersection<T extends Type[]> = MappedType<
-  UnionToIntersection<ClassRefsToConstructors<T>[number]>
+  RemoveFieldsWithType<
+    UnionToIntersection<ClassRefsToConstructors<T>[number]>,
+    Function
+  >
 >;
 
 export function IntersectionType<T extends Type[]>(...classRefs: T) {
@@ -47,5 +51,6 @@ export function IntersectionType<T extends Type[]>(...classRefs: T) {
   Object.defineProperty(IntersectionClassType, 'name', {
     value: `Intersection${intersectedNames}`,
   });
+
   return IntersectionClassType as Intersection<T>;
 }

--- a/lib/omit-type.helper.ts
+++ b/lib/omit-type.helper.ts
@@ -5,11 +5,12 @@ import {
   inheritTransformationMetadata,
   inheritValidationMetadata,
 } from './type-helpers.utils';
+import { RemoveFieldsWithType } from './types/remove-fields-with-type.type';
 
 export function OmitType<T, K extends keyof T>(
   classRef: Type<T>,
   keys: readonly K[],
-): MappedType<Omit<T, (typeof keys)[number]>> {
+) {
   const isInheritedPredicate = (propertyKey: string) =>
     !keys.includes(propertyKey as K);
 
@@ -22,5 +23,7 @@ export function OmitType<T, K extends keyof T>(
   inheritValidationMetadata(classRef, OmitClassType, isInheritedPredicate);
   inheritTransformationMetadata(classRef, OmitClassType, isInheritedPredicate);
 
-  return OmitClassType as MappedType<Omit<T, (typeof keys)[number]>>;
+  return OmitClassType as MappedType<
+    RemoveFieldsWithType<Omit<T, (typeof keys)[number]>, Function>
+  >;
 }

--- a/lib/omit-type.helper.ts
+++ b/lib/omit-type.helper.ts
@@ -9,7 +9,7 @@ import {
 export function OmitType<T, K extends keyof T>(
   classRef: Type<T>,
   keys: readonly K[],
-): MappedType<Omit<T, typeof keys[number]>> {
+): MappedType<Omit<T, (typeof keys)[number]>> {
   const isInheritedPredicate = (propertyKey: string) =>
     !keys.includes(propertyKey as K);
 
@@ -22,5 +22,5 @@ export function OmitType<T, K extends keyof T>(
   inheritValidationMetadata(classRef, OmitClassType, isInheritedPredicate);
   inheritTransformationMetadata(classRef, OmitClassType, isInheritedPredicate);
 
-  return OmitClassType as MappedType<Omit<T, typeof keys[number]>>;
+  return OmitClassType as MappedType<Omit<T, (typeof keys)[number]>>;
 }

--- a/lib/partial-type.helper.ts
+++ b/lib/partial-type.helper.ts
@@ -6,8 +6,9 @@ import {
   inheritTransformationMetadata,
   inheritValidationMetadata,
 } from './type-helpers.utils';
+import { RemoveFieldsWithType } from './types/remove-fields-with-type.type';
 
-export function PartialType<T>(classRef: Type<T>): MappedType<Partial<T>> {
+export function PartialType<T>(classRef: Type<T>) {
   abstract class PartialClassType {
     constructor() {
       inheritPropertyInitializers(this, classRef);
@@ -26,5 +27,8 @@ export function PartialType<T>(classRef: Type<T>): MappedType<Partial<T>> {
   Object.defineProperty(PartialClassType, 'name', {
     value: `Partial${classRef.name}`,
   });
-  return PartialClassType as MappedType<Partial<T>>;
+
+  return PartialClassType as MappedType<
+    RemoveFieldsWithType<Partial<T>, Function>
+  >;
 }

--- a/lib/pick-type.helper.ts
+++ b/lib/pick-type.helper.ts
@@ -9,7 +9,7 @@ import {
 export function PickType<T, K extends keyof T>(
   classRef: Type<T>,
   keys: readonly K[],
-): MappedType<Pick<T, typeof keys[number]>> {
+): MappedType<Pick<T, (typeof keys)[number]>> {
   const isInheritedPredicate = (propertyKey: string) =>
     keys.includes(propertyKey as K);
 
@@ -21,5 +21,5 @@ export function PickType<T, K extends keyof T>(
   inheritValidationMetadata(classRef, PickClassType, isInheritedPredicate);
   inheritTransformationMetadata(classRef, PickClassType, isInheritedPredicate);
 
-  return PickClassType as MappedType<Pick<T, typeof keys[number]>>;
+  return PickClassType as MappedType<Pick<T, (typeof keys)[number]>>;
 }

--- a/lib/pick-type.helper.ts
+++ b/lib/pick-type.helper.ts
@@ -5,11 +5,12 @@ import {
   inheritTransformationMetadata,
   inheritValidationMetadata,
 } from './type-helpers.utils';
+import { RemoveFieldsWithType } from './types/remove-fields-with-type.type';
 
 export function PickType<T, K extends keyof T>(
   classRef: Type<T>,
   keys: readonly K[],
-): MappedType<Pick<T, (typeof keys)[number]>> {
+) {
   const isInheritedPredicate = (propertyKey: string) =>
     keys.includes(propertyKey as K);
 
@@ -21,5 +22,7 @@ export function PickType<T, K extends keyof T>(
   inheritValidationMetadata(classRef, PickClassType, isInheritedPredicate);
   inheritTransformationMetadata(classRef, PickClassType, isInheritedPredicate);
 
-  return PickClassType as MappedType<Pick<T, (typeof keys)[number]>>;
+  return PickClassType as MappedType<
+    RemoveFieldsWithType<Pick<T, (typeof keys)[number]>, Function>
+  >;
 }

--- a/lib/types/remove-fields-with-type.type.ts
+++ b/lib/types/remove-fields-with-type.type.ts
@@ -1,0 +1,8 @@
+// With this util we could remove the keys with never type from the original type.
+type KeysWithoutType<T, Type> = {
+  [K in keyof T]: T[K] extends Type ? never : K;
+}[keyof T];
+
+export type RemoveFieldsWithType<T, Type> = {
+  [K in KeysWithoutType<T, Type>]: T[K];
+};


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

Referred this topic: https://github.com/nestjs/swagger/issues/2295#issuecomment-1430871647

The problem is related to how mapped types & JS inheritance works, the method belongs to the parent class and the mapped type is not attached to the parent, so when you try to access the method the property appears as undefined (but the type in typescript is set as the parent method, so it appears as it has been defined).

For that reason I just the add a new type to the project that removes the functions fields of the generated mapped types, to detect this kind of problem in transpilation instead of execution time. 

I had thought about adding the remove function time in the mapped type itself instead of each mapped type utils, but I think that is an implementation problem, and maybe this could be resolved in js for one or many of the mapped types.

I also removed the explicit type of the result in some of the mapped types, because all of them use a type assertion to transform the result (and by removing it we could avoid this duplication of types).

<!-- Please check the one that applies to this PR using "x". -->
- [x ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently, the generated mapped types has contains the function fields from the source, but when you try to access these properties in execution time you find that the value of the field is undefined instead of the function implementation, this can cause bugs.

Issue Number: N/A

## What is the new behavior?
Now the new mapped types don't contain the function type fields, so this problem could be detected before executing the code.

## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
The return type changes, It's not a big deal, but the user projects that are using the mapped types with functions and upgrade to the new version will find that the new types don't contain the function fields.
Currently, this is not working so these projects could detect this problem and fix it, but will fail in the first place.
