### PR TITLE
fix(types): `RemoveFieldsWithType` when excluding optional fields on `strictNullChecks: false` 

### DIFF
--- a/lib/types/remove-fields-with-type.type.ts
+++ b/lib/types/remove-fields-with-type.type.ts
@@ -1,23 +1,5 @@
-// With this util we could remove the keys with never type from the original type.
-type KeysWithoutType<T, Type> = {
-  [K in keyof T]: T[K] extends Type ? never : K;
+type KeysWithType<T, Type> = {
+  [K in keyof T]: T[K] extends Type ? K : never;
 }[keyof T];
 
-type KeysOfType<T, U> = { [K in keyof T]: T[K] extends U ? K : never }[keyof T];
-type RequiredKeys<T> = Exclude<
-  KeysOfType<T, Exclude<T[keyof T], undefined>>,
-  undefined
->;
-type OptionalKeys<T> = Exclude<keyof T, RequiredKeys<T>>;
-
-export type RemoveFieldsWithType<T, Type> = {
-  [K in KeysWithoutType<Pick<T, RequiredKeys<T>>, Type>]: Pick<
-    T,
-    RequiredKeys<T>
-  >[K];
-} & {
-  [K in KeysWithoutType<Pick<T, OptionalKeys<T>>, Type>]?: Pick<
-    T,
-    OptionalKeys<T>
-  >[K];
-};
+export type RemoveFieldsWithType<T, Type> = Exclude<T, KeysWithType<T, Type>>;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: closes #1124

## What is the new behavior?

this is the behavior regardless of the flag `strictNullChecks`:

![image](https://github.com/nestjs/mapped-types/assets/13461315/41e60bc9-bcad-4275-9df1-f2b1bcd50c61)

![image](https://github.com/nestjs/mapped-types/assets/13461315/3d82db60-b887-453f-a0eb-646ddf759c0d)


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I just inverted the logic. I'm not 100% sure on the fix because I didn't understand why the excluding logic was that one in first place, but it seems to work