### PR TITLE
fix: incorrect inherit _transformmetadatas #1212

### DIFF
--- a/lib/type-helpers.utils.ts
+++ b/lib/type-helpers.utils.ts
@@ -151,10 +151,17 @@ function inheritTransformerMetadata(
 
       if (metadataMap.has(targetClass)) {
         const existingRules = metadataMap.get(targetClass)!.entries();
-        metadataMap.set(
-          targetClass,
-          new Map([...existingRules, ...targetMetadataEntries]),
-        );
+        const mergeMap = new Map<string, any[]>();
+        [existingRules, targetMetadataEntries].forEach((entries) => {
+          for (const [valueKey, value] of entries) {
+            if (mergeMap.has(valueKey)) {
+              mergeMap.get(valueKey)!.push(...value);
+            } else {
+              mergeMap.set(valueKey, value);
+            }
+          }
+        });
+        metadataMap.set(targetClass, mergeMap);
       } else {
         metadataMap.set(targetClass, new Map(targetMetadataEntries));
       }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: [1212](https://github.com/nestjs/mapped-types/issues/1212)


## What is the new behavior?
Correct result:
```
{
  transformExecuteSequenceList: [ 'Grandparent', 'Parent', 'Children' ],
  childrenValue: 1
}
```

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
