### PR TITLE
fix: incorrect inherit transform metadata #1224

### DIFF
--- a/lib/type-helpers.utils.ts
+++ b/lib/type-helpers.utils.ts
@@ -152,10 +152,17 @@ function inheritTransformerMetadata(
       if (metadataMap.has(targetClass)) {
         const existingRules = metadataMap.get(targetClass)!.entries();
         const mergeMap = new Map<string, any[]>();
+
+        // array should merge, not overwrite.
         [existingRules, targetMetadataEntries].forEach((entries) => {
           for (const [valueKey, value] of entries) {
             if (mergeMap.has(valueKey)) {
-              mergeMap.get(valueKey)!.push(...value);
+              if (Array.isArray(mergeMap.get(valueKey))) {
+                mergeMap
+                  .get(valueKey)!
+                  .push(...(Array.isArray(value) ? value : [value]));
+              }
+              // do nothing, parent should not overwrite children metadata.
             } else {
               mergeMap.set(valueKey, value);
             }

--- a/lib/type-helpers.utils.ts
+++ b/lib/type-helpers.utils.ts
@@ -153,7 +153,6 @@ function inheritTransformerMetadata(
         const existingRules = metadataMap.get(targetClass)!.entries();
         const mergeMap = new Map<string, any[]>();
 
-        // array should merge, not overwrite.
         [existingRules, targetMetadataEntries].forEach((entries) => {
           for (const [valueKey, value] of entries) {
             if (mergeMap.has(valueKey)) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Expose and Type is not working.
Occur error
```
ERROR [MappedTypes] Transformer ("class-transformer") metadata cannot be inherited for "Parent" class.
ERROR [MappedTypes] TypeError: Spread syntax requires ...iterable[Symbol.iterator] to be a function
```

Issue Number: [1224](https://github.com/nestjs/mapped-types/issues/1224)


## What is the new behavior?
Expose and Type work successfully.
Error has been resolve.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
