### PR TITLE
feat(mapped-types): add skip null properties option to partial type

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -5,6 +5,7 @@ export * from './partial-type.helper';
 export * from './pick-type.helper';
 export {
   applyIsOptionalDecorator,
+  applyValidateIfDefinedDecorator,
   inheritPropertyInitializers,
   inheritTransformationMetadata,
   inheritValidationMetadata,

--- a/lib/partial-type.helper.ts
+++ b/lib/partial-type.helper.ts
@@ -2,13 +2,27 @@ import { Type } from '@nestjs/common';
 import { MappedType } from './mapped-type.interface';
 import {
   applyIsOptionalDecorator,
+  applyValidateIfDefinedDecorator,
   inheritPropertyInitializers,
   inheritTransformationMetadata,
   inheritValidationMetadata,
 } from './type-helpers.utils';
 import { RemoveFieldsWithType } from './types/remove-fields-with-type.type';
 
-export function PartialType<T>(classRef: Type<T>) {
+export function PartialType<T>(
+  classRef: Type<T>,
+  /**
+   *  Configuration options.
+   */
+  options: {
+    /**
+     * If true, validations will be ignored on a property if it is either null or undefined. If
+     * false, validations will be ignored only if the property is undefined.
+     * @default true
+     */
+    skipNullProperties?: boolean;
+  } = {},
+) {
   abstract class PartialClassType {
     constructor() {
       inheritPropertyInitializers(this, classRef);
@@ -20,7 +34,9 @@ export function PartialType<T>(classRef: Type<T>) {
 
   if (propertyKeys) {
     propertyKeys.forEach((key) => {
-      applyIsOptionalDecorator(PartialClassType, key);
+      options.skipNullProperties === false
+        ? applyValidateIfDefinedDecorator(PartialClassType, key)
+        : applyIsOptionalDecorator(PartialClassType, key);
     });
   }
 

--- a/lib/type-helpers.utils.ts
+++ b/lib/type-helpers.utils.ts
@@ -15,6 +15,20 @@ export function applyIsOptionalDecorator(
   decoratorFactory(targetClass.prototype, propertyKey);
 }
 
+export function applyValidateIfDefinedDecorator(
+  targetClass: Function,
+  propertyKey: string,
+) {
+  if (!isClassValidatorAvailable()) {
+    return;
+  }
+  const classValidator: typeof import('class-validator') = require('class-validator');
+  const decoratorFactory = classValidator.ValidateIf(
+    (_, value) => value !== undefined,
+  );
+  decoratorFactory(targetClass.prototype, propertyKey);
+}
+
 export function inheritValidationMetadata(
   parentClass: Type<any>,
   targetClass: Function,

--- a/tests/partial-type.helper.spec.ts
+++ b/tests/partial-type.helper.spec.ts
@@ -81,4 +81,44 @@ describe('PartialType', () => {
       expect(updateUserDto.login).toEqual('defaultLogin');
     });
   });
+
+  describe('Configuration options', () => {
+    it('should not ignore validations for null properties when `skipNullProperties` is false', async () => {
+      class UpdateUserDtoDisallowNull extends PartialType(CreateUserDto, {
+        skipNullProperties: false,
+      }) {}
+
+      const updateDto = new UpdateUserDtoDisallowNull();
+      updateDto.password = null as any;
+
+      const validationErrors = await validate(updateDto);
+
+      expect(validationErrors.length).toBe(1);
+      expect(validationErrors[0].constraints).toEqual({
+        isString: 'password must be a string',
+      });
+    });
+
+    it('should ignore validations on null properties when `skipNullProperties` is undefined', async () => {
+      const updateDto = new UpdateUserDto();
+      updateDto.password = null as any;
+
+      const validationErrors = await validate(updateDto);
+
+      expect(validationErrors.length).toBe(0);
+    });
+
+    it('should ignore validations on null properties when `skipNullProperties` is true', async () => {
+      class UpdateUserDtoAllowNull extends PartialType(CreateUserDto, {
+        skipNullProperties: true,
+      }) {}
+
+      const updateDto = new UpdateUserDtoAllowNull();
+      updateDto.password = null as any;
+
+      const validationErrors = await validate(updateDto);
+
+      expect(validationErrors.length).toBe(0);
+    });
+  });
 });


### PR DESCRIPTION
With this change, you can create a partial class which does not ignore validations on `null` properties, but ignores validations on `undefined` properties. Previously, every class created with PartialType ignored validations on `null` properties, which may be undesired if you are defining the DTO for a PATCH endpoint. If the option is not defined, the behaviour is unchanged from the previous behaviour.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

`PartialType` will return a class for which validations are ignored `null` properties (in addition to `undefined` properties).

## What is the new behavior?

`PartialType` can optionally return a class for which validations are ignored only for `undefined` properties, not `null` properties. This can be useful if you are creating a DTO for a PATCH endpoint: there may be a certain field, say `name`, that should not be `null`, but which doesn't need to be included in PATCH updates.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information

This feature was discussed [here](https://github.com/nestjs/swagger/issues/2623). Note that we will want to make a similar change to the `@nestjs/swagger` code.