### PR TITLE
fix: resolve decorator stacking issue with intersection type usage

### DIFF
--- a/lib/intersection-type.helper.ts
+++ b/lib/intersection-type.helper.ts
@@ -44,7 +44,7 @@ export function IntersectionType<T extends Type[]>(...classRefs: T) {
 
   classRefs.forEach((classRef) => {
     inheritValidationMetadata(classRef, IntersectionClassType);
-    inheritTransformationMetadata(classRef, IntersectionClassType);
+    inheritTransformationMetadata(classRef, IntersectionClassType, undefined, false);
   });
 
   const intersectedNames = classRefs.reduce((prev, ref) => prev + ref.name, '');

--- a/lib/type-helpers.utils.ts
+++ b/lib/type-helpers.utils.ts
@@ -95,6 +95,7 @@ export function inheritTransformationMetadata(
   parentClass: Type<any>,
   targetClass: Function,
   isPropertyInherited?: (key: string) => boolean,
+  stackDecorators = true
 ) {
   if (!isClassTransformerAvailable()) {
     return;
@@ -112,6 +113,7 @@ export function inheritTransformationMetadata(
         parentClass,
         targetClass,
         isPropertyInherited,
+        stackDecorators
       ),
     );
   } catch (err) {
@@ -127,6 +129,7 @@ function inheritTransformerMetadata(
   parentClass: Type<any>,
   targetClass: Function,
   isPropertyInherited?: (key: string) => boolean,
+  stackDecorators = true,
 ) {
   let classTransformer: any;
   try {
@@ -169,7 +172,7 @@ function inheritTransformerMetadata(
 
         [existingRules, targetMetadataEntries].forEach((entries) => {
           for (const [valueKey, value] of entries) {
-            if (mergeMap.has(valueKey)) {
+            if (mergeMap.has(valueKey) && stackDecorators) {
               const parentValue = mergeMap.get(valueKey);
 
               if (Array.isArray(parentValue)) {

--- a/tests/intersection-type.helper.spec.ts
+++ b/tests/intersection-type.helper.spec.ts
@@ -11,6 +11,10 @@ describe('IntersectionType', () => {
     @Transform(({ value }) => value + '_transformed')
     @MinLength(10)
     password!: string;
+
+    @Transform(({ value }) => value + '_transformed')
+    @MinLength(15)
+    repeatedProperty = 'repeatedPropertyValue';
   }
 
   class ClassB {
@@ -20,6 +24,10 @@ describe('IntersectionType', () => {
     @Transform(({ value }) => value + '_transformed')
     @MinLength(5)
     lastName!: string;
+
+    @Transform(({ value }) => value + '_transformed')
+    @IsString()
+    repeatedProperty = 'repeatedPropertyValue';
   }
 
   class UpdateUserDto extends IntersectionType(ClassA, ClassB) {}
@@ -32,22 +40,29 @@ describe('IntersectionType', () => {
       expect(validationKeys).toEqual([
         'login',
         'password',
+        'repeatedProperty',
         'firstName',
         'lastName',
+        'repeatedProperty',
       ]);
     });
+
     describe('when object does not fulfil validation rules', () => {
       it('"validate" should return validation errors', async () => {
         const updateDto = new UpdateUserDto();
         updateDto.password = '1234567';
+        updateDto.repeatedProperty = '014-characters';
 
         const validationErrors = await validate(updateDto);
 
-        expect(validationErrors.length).toEqual(2);
+        expect(validationErrors.length).toEqual(3);
         expect(validationErrors[0].constraints).toEqual({
           minLength: 'password must be longer than or equal to 10 characters',
         });
         expect(validationErrors[1].constraints).toEqual({
+          minLength: 'repeatedProperty must be longer than or equal to 15 characters',
+        });
+        expect(validationErrors[2].constraints).toEqual({
           minLength: 'lastName must be longer than or equal to 5 characters',
         });
       });
@@ -59,6 +74,7 @@ describe('IntersectionType', () => {
         updateDto.firstName = 'firstNameTest';
         updateDto.lastName = 'lastNameTest';
         updateDto.login = 'mylogintesttest';
+        updateDto.repeatedProperty = 'repeatedPropertyTestValue';
 
         const validationErrors = await validate(updateDto);
         expect(validationErrors.length).toEqual(0);
@@ -70,14 +86,18 @@ describe('IntersectionType', () => {
     it('should inherit transformer metadata', () => {
       const password = '1234567891011';
       const lastName = 'lastNameTest';
+      const repeatedProperty = 'repeatedPropertyTestValue';
 
       const updateDto = new UpdateUserDto();
       updateDto.password = password;
       updateDto.lastName = lastName;
+      updateDto.repeatedProperty = repeatedProperty;
 
       const transformedDto = instanceToInstance(updateDto);
+
       expect(transformedDto.lastName).toEqual(lastName + '_transformed');
       expect(transformedDto.password).toEqual(password + '_transformed');
+      expect(transformedDto.repeatedProperty).toEqual(repeatedProperty + '_transformed');
     });
   });
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: [1517](https://github.com/nestjs/mapped-types/issues/1517)


## What is the new behavior?

This PR fixes the issue introduced in PR https://github.com/nestjs/mapped-types/pull/1213, where allowing decorators to be stacked when using PickType also caused them to stack when using IntersectionType.

If you run the modified spec with the code currently in the main branch, you will receive the following error due to `@Transform` being executed twice.

![image](https://github.com/user-attachments/assets/38d64452-3c48-4eca-9c52-99ca52434aaf)



## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
